### PR TITLE
docs: Fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository gathers the slides for the courses AI & Humanities (Winter 2021)
 **Others courses**
 
 - [Julie Josse](http://juliejosse.com/), [Erwan Scornet](https://erwanscornet.github.io/), [Imke Mayer](https://www.imkemayer.com/)'s slides.
-- Florian Oswald, please see his incredible [repository](ScPoEconometrics)
+- Florian Oswald, please see his incredible [repository](https://github.com/ScPoEcon/ScPoEconometrics)
 - A Crash Course in Causality: Inferring Causal Effects from Observational Data on [coursera](https://www.coursera.org/learn/crash-course-in-causality)
 
 **Books**


### PR DESCRIPTION
GitHub internal auto-links (e.g. `Username/Repository`) are bound to conversations (it does not work in `.md` files).
See https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls